### PR TITLE
merge configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,14 @@ go install https://github.com.com/mitsimi/aocli
 
 ### Configuration
 
-The program looks for a configuration file in the following places in order:
+The program looks for a configuration file in the following places:
 
-1. file provided via the flag
+1. home folder (~)
 2. project folder
-3. home folder (~)
-4. ~/.config
+3. file provided via the flag
+
+The configuration values getting merged in the order above. The last value (flag) wins. This means that you can provide a default configuration in your home folder and override it with a project specific configuration.
+This should should help to have the session token somewhere safe and not in the project folder, so it can't be leaked.
 
 The configuration file is either a TOML, YAML or JSON file with the following keys:
 | Key | Description | Default | Possible Values |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,23 @@ type Config struct {
 	Structure string `json:"structure" yaml:"structure" toml:"structure"`
 }
 
+// Merge merges two Configs, with the values of the second Config taking precedence.
+// If a field is not set in the second Config, the value from the first Config is used.
+// The result is a new Config.
+func Merge(a, b *Config) *Config {
+	if b.Session != "" {
+		a.Session = b.Session
+	}
+	if b.Year != 0 {
+		a.Year = b.Year
+	}
+	if b.Structure != "" {
+		a.Structure = b.Structure
+	}
+
+	return a
+}
+
 func Parse(path string) (*Config, error) {
 	switch ext := filepath.Ext(path); ext {
 	case ".json":


### PR DESCRIPTION
Now it merges found configs to enable people to store their session token in the home directory and structure, year config in the project folder. This should also help to prevent accidental leakage of the token.

closes #1 